### PR TITLE
Concurrency errors and deep nesting

### DIFF
--- a/src/main/java/spinnery/widget/WCollection.java
+++ b/src/main/java/spinnery/widget/WCollection.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface WCollection {
 	List<WWidget> getWidgets();
-	List<WWidget> getWidgetsDeep();
+	List<WWidget> getAllWidgets();
 }

--- a/src/main/java/spinnery/widget/WCollection.java
+++ b/src/main/java/spinnery/widget/WCollection.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 public interface WCollection {
 	List<WWidget> getWidgets();
+	List<WWidget> getWidgetsDeep();
 }

--- a/src/main/java/spinnery/widget/WDropdown.java
+++ b/src/main/java/spinnery/widget/WDropdown.java
@@ -66,6 +66,18 @@ public class WDropdown extends WWidget implements WClient, WCollection {
 	}
 
 	@Override
+	public List<WWidget> getWidgetsDeep() {
+		List<WWidget> widgets = new ArrayList<>();
+		for (List<WWidget> widgetA : getDropdownWidgets()) {
+			widgets.addAll(widgetA);
+			if (widgetA instanceof WCollection) {
+				widgets.addAll(((WCollection) widgetA).getWidgetsDeep());
+			}
+		}
+		return widgets;
+	}
+
+	@Override
 	public void onMouseClicked(int mouseX, int mouseY, int mouseButton) {
 		if (getFocus() && mouseButton == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
 			setState(!getState());

--- a/src/main/java/spinnery/widget/WDropdown.java
+++ b/src/main/java/spinnery/widget/WDropdown.java
@@ -66,12 +66,12 @@ public class WDropdown extends WWidget implements WClient, WCollection {
 	}
 
 	@Override
-	public List<WWidget> getWidgetsDeep() {
+	public List<WWidget> getAllWidgets() {
 		List<WWidget> widgets = new ArrayList<>();
 		for (List<WWidget> widgetA : getDropdownWidgets()) {
 			widgets.addAll(widgetA);
 			if (widgetA instanceof WCollection) {
-				widgets.addAll(((WCollection) widgetA).getWidgetsDeep());
+				widgets.addAll(((WCollection) widgetA).getAllWidgets());
 			}
 		}
 		return widgets;

--- a/src/main/java/spinnery/widget/WInterfaceHolder.java
+++ b/src/main/java/spinnery/widget/WInterfaceHolder.java
@@ -33,13 +33,13 @@ public class WInterfaceHolder {
 		return widgets;
 	}
 
-	public List<WWidget> getNonConcurrentDeep() {
+	public List<WWidget> getAllWidgets() {
 		List<WWidget> nonConcurrentList = new ArrayList<>();
 		for (WInterface myInterface : getInterfaces()) {
 			for (WWidget widgetA : myInterface.getWidgets()) {
 				nonConcurrentList.add(widgetA);
 				if (widgetA instanceof WCollection) {
-					nonConcurrentList.addAll(((WCollection) widgetA).getWidgetsDeep());
+					nonConcurrentList.addAll(((WCollection) widgetA).getAllWidgets());
 				}
 			}
 		}
@@ -47,7 +47,7 @@ public class WInterfaceHolder {
 	}
 
 	public boolean onMouseClicked(int mouseX, int mouseY, int mouseButton) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onMouseClicked(mouseX, mouseY, mouseButton);
 		}
 		return false;
@@ -55,7 +55,7 @@ public class WInterfaceHolder {
 
 
 	public boolean onMouseReleased(int mouseX, int mouseY, int mouseButton) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onMouseReleased(mouseX, mouseY, mouseButton);
 		}
 		return false;
@@ -63,7 +63,7 @@ public class WInterfaceHolder {
 
 
 	public boolean onMouseDragged(int mouseX, int mouseY, int mouseButton, int deltaX, int deltaY) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onMouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
 		}
 		return false;
@@ -71,14 +71,14 @@ public class WInterfaceHolder {
 
 
 	public boolean onMouseScrolled(int mouseX, int mouseY, double deltaY) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onMouseScrolled(mouseX, mouseY, deltaY);
 		}
 		return false;
 	}
 
 	public void mouseMoved(int mouseX, int mouseY) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.scanFocus(mouseX, mouseY);
 			widget.onMouseMoved(mouseX, mouseY);
 		}
@@ -86,7 +86,7 @@ public class WInterfaceHolder {
 
 
 	public boolean onKeyReleased(int character, int keyCode, int keyModifier) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onKeyReleased(keyCode);
 			widget.onKeyReleased(keyCode);
 		}
@@ -94,7 +94,7 @@ public class WInterfaceHolder {
 	}
 
 	public boolean keyPressed(int character, int keyCode, int keyModifier) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onKeyPressed(character, keyCode, keyModifier);
 		}
 		return false;
@@ -102,20 +102,20 @@ public class WInterfaceHolder {
 
 
 	public boolean onCharTyped(char character, int keyCode) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onCharTyped(character);
 		}
 		return false;
 	}
 
 	public void drawMouseoverTooltip(int mouseX, int mouseY) {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.onDrawTooltip();
 		}
 	}
 
 	public void tick() {
-		for (WWidget widget : getNonConcurrentDeep()) {
+		for (WWidget widget : getAllWidgets()) {
 			widget.tick();
 		}
 	}

--- a/src/main/java/spinnery/widget/WInterfaceHolder.java
+++ b/src/main/java/spinnery/widget/WInterfaceHolder.java
@@ -33,165 +33,90 @@ public class WInterfaceHolder {
 		return widgets;
 	}
 
-	public boolean onMouseClicked(int mouseX, int mouseY, int mouseButton) {
+	public List<WWidget> getNonConcurrentDeep() {
+		List<WWidget> nonConcurrentList = new ArrayList<>();
 		for (WInterface myInterface : getInterfaces()) {
 			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onMouseClicked(mouseX, mouseY, mouseButton);
-
+				nonConcurrentList.add(widgetA);
 				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onMouseClicked(mouseX, mouseY, mouseButton);
-					}
+					nonConcurrentList.addAll(((WCollection) widgetA).getWidgetsDeep());
 				}
 			}
 		}
+		return nonConcurrentList;
+	}
 
+	public boolean onMouseClicked(int mouseX, int mouseY, int mouseButton) {
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onMouseClicked(mouseX, mouseY, mouseButton);
+		}
 		return false;
 	}
 
 
 	public boolean onMouseReleased(int mouseX, int mouseY, int mouseButton) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onMouseReleased(mouseX, mouseY, mouseButton);
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onMouseReleased(mouseX, mouseY, mouseButton);
-
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onMouseReleased(mouseX, mouseY, mouseButton);
 		}
 		return false;
 	}
 
 
 	public boolean onMouseDragged(int mouseX, int mouseY, int mouseButton, int deltaX, int deltaY) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onMouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onMouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
-
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onMouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
 		}
-
 		return false;
 	}
 
 
 	public boolean onMouseScrolled(int mouseX, int mouseY, double deltaY) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onMouseScrolled(mouseX, mouseY, deltaY);
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onMouseScrolled(mouseX, mouseY, deltaY);
-
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onMouseScrolled(mouseX, mouseY, deltaY);
 		}
-
 		return false;
 	}
 
 	public void mouseMoved(int mouseX, int mouseY) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.scanFocus(mouseX, mouseY);
-				widgetA.onMouseMoved(mouseX, mouseY);
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.scanFocus(mouseX, mouseY);
-						widgetB.onMouseMoved(mouseX, mouseY);
-
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.scanFocus(mouseX, mouseY);
+			widget.onMouseMoved(mouseX, mouseY);
 		}
 	}
 
 
 	public boolean onKeyReleased(int character, int keyCode, int keyModifier) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onKeyReleased(keyCode);
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onKeyReleased(keyCode);
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onKeyReleased(keyCode);
+			widget.onKeyReleased(keyCode);
 		}
 		return false;
 	}
 
 	public boolean keyPressed(int character, int keyCode, int keyModifier) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onKeyPressed(character, keyCode, keyModifier);
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onKeyPressed(character, keyCode, keyModifier);
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onKeyPressed(character, keyCode, keyModifier);
 		}
 		return false;
 	}
 
 
 	public boolean onCharTyped(char character, int keyCode) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onCharTyped(character);
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onCharTyped(character);
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onCharTyped(character);
 		}
-
 		return false;
 	}
 
 	public void drawMouseoverTooltip(int mouseX, int mouseY) {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.onDrawTooltip();
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.onDrawTooltip();
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.onDrawTooltip();
 		}
 	}
 
 	public void tick() {
-		for (WInterface myInterface : getInterfaces()) {
-			for (WWidget widgetA : myInterface.getWidgets()) {
-				widgetA.tick();
-
-				if (widgetA instanceof WCollection) {
-					for (WWidget widgetB : ((WCollection) widgetA).getWidgets()) {
-						widgetB.tick();
-					}
-				}
-			}
+		for (WWidget widget : getNonConcurrentDeep()) {
+			widget.tick();
 		}
 	}
 

--- a/src/main/java/spinnery/widget/WList.java
+++ b/src/main/java/spinnery/widget/WList.java
@@ -47,6 +47,18 @@ public class WList extends WWidget implements WClient, WCollection {
 		return widgets;
 	}
 
+	@Override
+	public List<WWidget> getWidgetsDeep() {
+		List<WWidget> widgets = new ArrayList<>();
+		for (List<WWidget> widgetA : getListWidgets()) {
+			widgets.addAll(widgetA);
+			if (widgetA instanceof WCollection) {
+				widgets.addAll(((WCollection) widgetA).getWidgetsDeep());
+			}
+		}
+		return widgets;
+	}
+
 	public List<List<WWidget>> getListWidgets() {
 		return listWidgets;
 	}

--- a/src/main/java/spinnery/widget/WList.java
+++ b/src/main/java/spinnery/widget/WList.java
@@ -48,12 +48,12 @@ public class WList extends WWidget implements WClient, WCollection {
 	}
 
 	@Override
-	public List<WWidget> getWidgetsDeep() {
+	public List<WWidget> getAllWidgets() {
 		List<WWidget> widgets = new ArrayList<>();
 		for (List<WWidget> widgetA : getListWidgets()) {
 			widgets.addAll(widgetA);
 			if (widgetA instanceof WCollection) {
-				widgets.addAll(((WCollection) widgetA).getWidgetsDeep());
+				widgets.addAll(((WCollection) widgetA).getAllWidgets());
 			}
 		}
 		return widgets;

--- a/src/main/java/spinnery/widget/WTabHolder.java
+++ b/src/main/java/spinnery/widget/WTabHolder.java
@@ -71,10 +71,10 @@ public class WTabHolder extends WWidget implements WClient, WCollection {
 	}
 
 	@Override
-	public List<WWidget> getWidgetsDeep() {
+	public List<WWidget> getAllWidgets() {
 		List<WWidget> widgets = new LinkedList<>();
 		for (int i : tabs.keySet()) {
-			widgets.addAll(tabs.get(i).getWidgetsDeep());
+			widgets.addAll(tabs.get(i).getAllWidgets());
 		}
 		return widgets;
 	}
@@ -150,11 +150,11 @@ public class WTabHolder extends WWidget implements WClient, WCollection {
 		}
 
 		@Override
-		public List<WWidget> getWidgetsDeep() {
+		public List<WWidget> getAllWidgets() {
 			List<WWidget> deepList = new ArrayList<>(widgets);
 			for (WWidget widgetA : widgets) {
 				if (widgetA instanceof WCollection) {
-					deepList.addAll(((WCollection) widgetA).getWidgetsDeep());
+					deepList.addAll(((WCollection) widgetA).getAllWidgets());
 				}
 			}
 			return deepList;

--- a/src/main/java/spinnery/widget/WTabHolder.java
+++ b/src/main/java/spinnery/widget/WTabHolder.java
@@ -4,11 +4,7 @@ import net.minecraft.item.Item;
 import net.minecraft.text.Text;
 import spinnery.client.BaseRenderer;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class WTabHolder extends WWidget implements WClient, WCollection {
 	public static final int SHADOW = 0;
@@ -75,6 +71,15 @@ public class WTabHolder extends WWidget implements WClient, WCollection {
 	}
 
 	@Override
+	public List<WWidget> getWidgetsDeep() {
+		List<WWidget> widgets = new LinkedList<>();
+		for (int i : tabs.keySet()) {
+			widgets.addAll(tabs.get(i).getWidgetsDeep());
+		}
+		return widgets;
+	}
+
+	@Override
 	public void align() {
 		super.align();
 
@@ -122,7 +127,7 @@ public class WTabHolder extends WWidget implements WClient, WCollection {
 		}
 	}
 
-	public class WTab {
+	public class WTab implements WCollection {
 		Item symbol;
 		Text name;
 		int number;
@@ -142,6 +147,17 @@ public class WTabHolder extends WWidget implements WClient, WCollection {
 
 		public List<WWidget> getWidgets() {
 			return widgets;
+		}
+
+		@Override
+		public List<WWidget> getWidgetsDeep() {
+			List<WWidget> deepList = new ArrayList<>(widgets);
+			for (WWidget widgetA : widgets) {
+				if (widgetA instanceof WCollection) {
+					deepList.addAll(((WCollection) widgetA).getWidgetsDeep());
+				}
+			}
+			return deepList;
 		}
 
 		public WTabToggle getToggle() {


### PR DESCRIPTION
Collect callback widgets to temp list to avoid concurrent modification errors, add support for getting a deep-nested widget list.

Using a temporary list for callbacks allows the user to modify the layout from inside the callback.