### PR TITLE
Change ordering in onAlign and properly hide children in WDropdown#setState

### DIFF
--- a/src/main/java/spinnery/widget/WAbstractWidget.java
+++ b/src/main/java/spinnery/widget/WAbstractWidget.java
@@ -506,13 +506,13 @@ public abstract class WAbstractWidget implements Tickable,
 	@Environment(EnvType.CLIENT)
 	@Override
 	public void onAlign() {
+		if (runnableOnAlign != null) {
+			runnableOnAlign.event(this);
+		}
 		if (this instanceof WDelegatedEventListener) {
 			for (WEventListener widget : ((WDelegatedEventListener) this).getEventDelegates()) {
 				widget.onAlign();
 			}
-		}
-		if (runnableOnAlign != null) {
-			runnableOnAlign.event(this);
 		}
 		onLayoutChange();
 	}

--- a/src/main/java/spinnery/widget/WDropdown.java
+++ b/src/main/java/spinnery/widget/WDropdown.java
@@ -171,6 +171,7 @@ public class WDropdown extends WAbstractWidget implements WDrawableCollection, W
 	@SuppressWarnings("UnusedReturnValue")
 	public <W extends WDropdown> W setState(boolean state) {
 		this.state = state;
+		updateChildren();
 		return (W) this;
 	}
 


### PR DESCRIPTION
First run `runnableOnAlign` and after that call the onAlign method in children.
This means that children can rely on the correct size of its parent to resize themselves.

Also added `updateChildren` in `WDropdown#setState`.
If you call `setState` yourself before, the children would not get hidden.