### PR TITLE
Deprecate reflective APIs

### DIFF
--- a/src/main/java/spinnery/util/EventUtilities.java
+++ b/src/main/java/spinnery/util/EventUtilities.java
@@ -12,9 +12,11 @@ public class EventUtilities {
 	 *
 	 * @return true if mouse event should go through
 	 */
+	@SuppressWarnings("deprecation")
 	public static <T extends WEventListener> boolean canReceiveMouse(T target) {
 		if (target instanceof WAbstractWidget) {
-			return !target.getClass().isAnnotationPresent(WFocusedMouseListener.class) || ((WAbstractWidget) target).isFocused();
+			WAbstractWidget widget = (WAbstractWidget) target;
+			return !(widget.isFocusedMouseListener() || target.getClass().isAnnotationPresent(WFocusedMouseListener.class)) || widget.isFocused();
 		}
 		return true;
 	}
@@ -25,9 +27,11 @@ public class EventUtilities {
 	 *
 	 * @return true if mouse event should go through
 	 */
+	@SuppressWarnings("deprecation")
 	public static <T extends WEventListener> boolean canReceiveKeyboard(T target) {
 		if (target instanceof WAbstractWidget) {
-			return !target.getClass().isAnnotationPresent(WFocusedKeyboardListener.class) || ((WAbstractWidget) target).isFocused();
+			WAbstractWidget widget = (WAbstractWidget) target;
+			return !(widget.isFocusedKeyboardListener() || target.getClass().isAnnotationPresent(WFocusedKeyboardListener.class)) || widget.isFocused();
 		}
 		return true;
 	}

--- a/src/main/java/spinnery/widget/WAbstractSlider.java
+++ b/src/main/java/spinnery/widget/WAbstractSlider.java
@@ -102,6 +102,16 @@ public abstract class WAbstractSlider extends WAbstractWidget implements WPadded
 	public abstract Size getKnobSize();
 
 	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
+	}
+
+	@Override
+	public boolean isFocusedKeyboardListener() {
+		return true;
+	}
+
+	@Override
 	public void onKeyPressed(int keyPressed, int character, int keyModifier) {
 		if (keyPressed == GLFW.GLFW_KEY_KP_ADD || keyPressed == GLFW.GLFW_KEY_EQUAL) {
 			progress = Math.min(progress + step, max);

--- a/src/main/java/spinnery/widget/WAbstractTextEditor.java
+++ b/src/main/java/spinnery/widget/WAbstractTextEditor.java
@@ -248,6 +248,11 @@ public abstract class WAbstractTextEditor extends WAbstractWidget implements WPa
 	}
 
 	@Override
+	public boolean isFocusedKeyboardListener() {
+		return true;
+	}
+
+	@Override
 	public boolean isFocused() {
 		return super.isFocused() || active;
 	}

--- a/src/main/java/spinnery/widget/WAbstractWidget.java
+++ b/src/main/java/spinnery/widget/WAbstractWidget.java
@@ -257,6 +257,26 @@ public abstract class WAbstractWidget implements Tickable,
 		return (W) this;
 	}
 
+	/**
+	 * Returns true if this widget only listens for keyboard events when focused, that is, when
+	 * {@link #isFocused()} returns <tt>true</tt>.
+	 *
+	 * @return true if this widget is a focused keyboard listener
+	 */
+	public boolean isFocusedKeyboardListener() {
+		return false;
+	}
+
+	/**
+	 * Returns true if this widget only listens for mouse events when focused, that is, when
+	 * {@link #isFocused()} returns <tt>true</tt>.
+	 *
+	 * @return true if this widget is a focused mouse listener
+	 */
+	public boolean isFocusedMouseListener() {
+		return false;
+	}
+
 	@Environment(EnvType.CLIENT)
 	@Override
 	public void onKeyPressed(int keyPressed, int character, int keyModifier) {

--- a/src/main/java/spinnery/widget/WButton.java
+++ b/src/main/java/spinnery/widget/WButton.java
@@ -4,10 +4,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import spinnery.client.BaseRenderer;
 import spinnery.client.TextRenderer;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedMouseListener
 public class WButton extends WAbstractButton {
 	@Override
 	public void draw() {
@@ -27,5 +25,10 @@ public class WButton extends WAbstractButton {
 					.shadow(getStyle().asBoolean("label.shadow")).shadowColor(getStyle().asColor("label.shadow_color"))
 					.color(getStyle().asColor("label.color")).render();
 		}
+	}
+
+	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
 	}
 }

--- a/src/main/java/spinnery/widget/WDynamicImage.java
+++ b/src/main/java/spinnery/widget/WDynamicImage.java
@@ -4,10 +4,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.util.Identifier;
 import spinnery.client.BaseRenderer;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedMouseListener
 public class WDynamicImage extends WAbstractWidget {
 	protected Identifier[] textures;
 
@@ -65,5 +63,10 @@ public class WDynamicImage extends WAbstractWidget {
 
 	public Identifier getTexture() {
 		return textures[currentImage];
+	}
+
+	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
 	}
 }

--- a/src/main/java/spinnery/widget/WHorizontalSlider.java
+++ b/src/main/java/spinnery/widget/WHorizontalSlider.java
@@ -6,12 +6,8 @@ import spinnery.client.BaseRenderer;
 import spinnery.client.TextRenderer;
 import spinnery.widget.api.Position;
 import spinnery.widget.api.Size;
-import spinnery.widget.api.WFocusedKeyboardListener;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedKeyboardListener
-@WFocusedMouseListener
 public class WHorizontalSlider extends WAbstractSlider {
 	@Override
 	public void draw() {

--- a/src/main/java/spinnery/widget/WSlot.java
+++ b/src/main/java/spinnery/widget/WSlot.java
@@ -66,7 +66,7 @@ public class WSlot extends WAbstractWidget {
 	public static void addArray(Position position, Size size, WModifiableCollection parent, int slotNumber, int inventoryNumber, int arrayWidth, int arrayHeight) {
 		for (int y = 0; y < arrayHeight; ++y) {
 			for (int x = 0; x < arrayWidth; ++x) {
-				parent.createChild(WSlot.class, position.add(size.getWidth() * x, size.getHeight() * y, 0), size)
+				parent.createChild(WSlot::new, position.add(size.getWidth() * x, size.getHeight() * y, 0), size)
 						.setSlotNumber(slotNumber + y * arrayWidth + x)
 						.setInventoryNumber(inventoryNumber);
 			}
@@ -83,7 +83,7 @@ public class WSlot extends WAbstractWidget {
 	public static void addHeadlessArray(WModifiableCollection parent, int slotNumber, int inventoryNumber, int arrayWidth, int arrayHeight) {
 		for (int y = 0; y < arrayHeight; ++y) {
 			for (int x = 0; x < arrayWidth; ++x) {
-				parent.createChild(WSlot.class)
+				parent.createChild(WSlot::new)
 						.setSlotNumber(slotNumber + y * arrayWidth + x)
 						.setInventoryNumber(inventoryNumber);
 			}

--- a/src/main/java/spinnery/widget/WStaticImage.java
+++ b/src/main/java/spinnery/widget/WStaticImage.java
@@ -4,10 +4,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.util.Identifier;
 import spinnery.client.BaseRenderer;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedMouseListener
 public class WStaticImage extends WAbstractWidget {
 	protected Identifier texture;
 
@@ -34,5 +32,10 @@ public class WStaticImage extends WAbstractWidget {
 	public <W extends WStaticImage> W setTexture(Identifier texture) {
 		this.texture = texture;
 		return (W) this;
+	}
+
+	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
 	}
 }

--- a/src/main/java/spinnery/widget/WStaticText.java
+++ b/src/main/java/spinnery/widget/WStaticText.java
@@ -5,10 +5,8 @@ import net.fabricmc.api.Environment;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import spinnery.client.TextRenderer;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedMouseListener
 public class WStaticText extends WAbstractWidget {
 	protected Text text = new LiteralText("");
 	protected double scale = 1.0;
@@ -79,5 +77,10 @@ public class WStaticText extends WAbstractWidget {
 	public <W extends WStaticText> W setText(String text) {
 		this.text = new LiteralText(text);
 		return (W) this;
+	}
+
+	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
 	}
 }

--- a/src/main/java/spinnery/widget/WTabToggle.java
+++ b/src/main/java/spinnery/widget/WTabToggle.java
@@ -8,11 +8,9 @@ import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 import spinnery.client.BaseRenderer;
 import spinnery.client.TextRenderer;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @SuppressWarnings("unchecked")
 @Environment(EnvType.CLIENT)
-@WFocusedMouseListener
 public class WTabToggle extends WAbstractToggle {
 	protected ItemConvertible symbol;
 
@@ -61,5 +59,10 @@ public class WTabToggle extends WAbstractToggle {
 	public <W extends WTabToggle> W setSymbol(ItemConvertible symbol) {
 		this.symbol = symbol;
 		return (W) this;
+	}
+
+	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
 	}
 }

--- a/src/main/java/spinnery/widget/WTextArea.java
+++ b/src/main/java/spinnery/widget/WTextArea.java
@@ -5,13 +5,11 @@ import net.fabricmc.api.Environment;
 import org.lwjgl.glfw.GLFW;
 import spinnery.client.BaseRenderer;
 import spinnery.client.TextRenderer;
-import spinnery.widget.api.WFocusedKeyboardListener;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Environment(EnvType.CLIENT)
-@WFocusedKeyboardListener
 public class WTextArea extends WAbstractTextEditor {
 	// Keep track of which lines are "wrapped" and which are hard newlines
 	protected final List<Boolean> newLine = new ArrayList<>();

--- a/src/main/java/spinnery/widget/WTextField.java
+++ b/src/main/java/spinnery/widget/WTextField.java
@@ -3,10 +3,8 @@ package spinnery.widget;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import spinnery.client.BaseRenderer;
-import spinnery.widget.api.WFocusedKeyboardListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedKeyboardListener
 public class WTextField extends WAbstractTextEditor {
 	protected Integer fixedLength;
 

--- a/src/main/java/spinnery/widget/WTexturedButton.java
+++ b/src/main/java/spinnery/widget/WTexturedButton.java
@@ -4,10 +4,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.util.Identifier;
 import spinnery.client.BaseRenderer;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedMouseListener
 public class WTexturedButton extends WAbstractWidget {
 	protected Identifier inactive;
 	protected Identifier active;
@@ -80,5 +78,10 @@ public class WTexturedButton extends WAbstractWidget {
 	public void onMouseClicked(int mouseX, int mouseY, int mouseButton) {
 		if (isDisabled) return;
 		super.onMouseClicked(mouseX, mouseY, mouseButton);
+	}
+
+	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
 	}
 }

--- a/src/main/java/spinnery/widget/WToggle.java
+++ b/src/main/java/spinnery/widget/WToggle.java
@@ -4,10 +4,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import spinnery.client.BaseRenderer;
 import spinnery.client.TextRenderer;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedMouseListener
 public class WToggle extends WAbstractToggle {
 	@Override
 	public void draw() {
@@ -41,5 +39,10 @@ public class WToggle extends WAbstractToggle {
 					.text(getLabel()).at(x + sX + 2, y + sY / 2 - 4.5, z)
 					.color(getStyle().asColor("label.color")).shadowColor(getStyle().asColor("label.shadow_color")).render();
 		}
+	}
+
+	@Override
+	public boolean isFocusedMouseListener() {
+		return true;
 	}
 }

--- a/src/main/java/spinnery/widget/WVerticalSlider.java
+++ b/src/main/java/spinnery/widget/WVerticalSlider.java
@@ -6,12 +6,8 @@ import spinnery.client.BaseRenderer;
 import spinnery.client.TextRenderer;
 import spinnery.widget.api.Position;
 import spinnery.widget.api.Size;
-import spinnery.widget.api.WFocusedKeyboardListener;
-import spinnery.widget.api.WFocusedMouseListener;
 
 @Environment(EnvType.CLIENT)
-@WFocusedKeyboardListener
-@WFocusedMouseListener
 public class WVerticalSlider extends WAbstractSlider {
 	@Override
 	public void draw() {

--- a/src/main/java/spinnery/widget/WWidgetFactory.java
+++ b/src/main/java/spinnery/widget/WWidgetFactory.java
@@ -9,7 +9,10 @@ import spinnery.widget.api.WModifiableCollection;
  * This class represents the mechanism for creating widgets given a widget type. Instances of this class must
  * have a non-null {@link WModifiableCollection} <tt>parent</tt>, which widgets created via {@link #build(Class)}
  * are automatically added to.
+ *
+ * @deprecated Reflective APIs for adding widgets are deprecated.
  */
+@Deprecated
 public class WWidgetFactory {
 	protected WModifiableCollection parent;
 

--- a/src/main/java/spinnery/widget/api/WFocusedKeyboardListener.java
+++ b/src/main/java/spinnery/widget/api/WFocusedKeyboardListener.java
@@ -9,7 +9,10 @@ import java.lang.annotation.RetentionPolicy;
  * Specifies that the annotated widget only listens for keyboard events when focused, that is, when
  * {@link WAbstractWidget#isFocused()} returns <tt>true</tt>. This behavior is not inherited by child
  * classes!
+ *
+ * @deprecated Replaced with {@link WAbstractWidget#isFocusedKeyboardListener()}.
  */
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WFocusedKeyboardListener {
 }

--- a/src/main/java/spinnery/widget/api/WFocusedMouseListener.java
+++ b/src/main/java/spinnery/widget/api/WFocusedMouseListener.java
@@ -9,7 +9,10 @@ import java.lang.annotation.RetentionPolicy;
  * Specifies that the annotated widget only listens for mouse events when focused, that is, when
  * {@link WAbstractWidget#isFocused()} returns <tt>true</tt>. This behavior is not inherited by child
  * classes!
+ *
+ * @deprecated Replaced with {@link WAbstractWidget#isFocusedMouseListener()}.
  */
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WFocusedMouseListener {
 }

--- a/src/main/java/spinnery/widget/api/WModifiableCollection.java
+++ b/src/main/java/spinnery/widget/api/WModifiableCollection.java
@@ -1,7 +1,10 @@
 package spinnery.widget.api;
 
 import spinnery.widget.WAbstractWidget;
+import spinnery.widget.WInterface;
 import spinnery.widget.WWidgetFactory;
+
+import java.util.function.Supplier;
 
 /**
  * Generic interface representing a collection of widgets that may be modified by adding or removing widgets.
@@ -30,9 +33,21 @@ public interface WModifiableCollection extends WCollection {
 	 *
 	 * @param wClass widget class
 	 * @return created widget
+	 * @deprecated Reflective APIs for adding widgets are deprecated. Use {@link #createChild(Supplier)} instead.
 	 */
+	@Deprecated
 	default <W extends WAbstractWidget> W createChild(Class<W> wClass) {
 		return createChild(wClass, null, null);
+	}
+
+	/**
+	 * Convenience method for short-circuiting <tt>factory.get()</tt>.
+	 *
+	 * @param factory widget factory
+	 * @return created widget
+	 */
+	default <W extends WAbstractWidget> W createChild(Supplier<W> factory) {
+		return createChild(factory, null, null);
 	}
 
 	/**
@@ -43,11 +58,39 @@ public interface WModifiableCollection extends WCollection {
 	 * @param position initial widget position
 	 * @param size     initial widget size
 	 * @return created widget
+	 * @deprecated Reflective APIs for adding widgets are deprecated. Use {@link #createChild(Supplier, Position, Size)} instead.
 	 */
+	@Deprecated
 	default <W extends WAbstractWidget> W createChild(Class<W> wClass, Position position, Size size) {
-		W widget = getFactory().build(wClass);
+		return createChild(() -> getFactory().build(wClass), position, size);
+	}
+
+	/**
+	 * Convenience method for short-circuiting <tt>factory.get()</tt> and setting the widget's
+	 * position and size.
+	 *
+	 * @param factory  widget factory
+	 * @param position initial widget position
+	 * @param size     initial widget size
+	 * @return created widget
+	 */
+	default <W extends WAbstractWidget> W createChild(Supplier<? extends W> factory, Position position, Size size) {
+		W widget = factory.get();
 		if (position != null) widget.setPosition(position);
 		if (size != null) widget.setSize(size);
+
+		if (this instanceof WAbstractWidget) {
+			widget.setInterface(((WAbstractWidget) this).getInterface());
+		} else if (this instanceof WInterface) {
+			widget.setInterface((WInterface) this);
+		}
+
+		if (this instanceof WLayoutElement) {
+			widget.setParent((WLayoutElement) this);
+		}
+
+		add(widget);
+
 		return widget;
 	}
 
@@ -55,7 +98,9 @@ public interface WModifiableCollection extends WCollection {
 	 * Gets the widget factory for creating children of this modifiable collection.
 	 *
 	 * @return widget factory instance
+	 * @deprecated Reflective APIs for adding widgets are deprecated.
 	 */
+	@Deprecated
 	default WWidgetFactory getFactory() {
 		return new WWidgetFactory(this);
 	}
@@ -67,8 +112,22 @@ public interface WModifiableCollection extends WCollection {
 	 * @param wClass   widget class
 	 * @param position initial widget position
 	 * @return created widget
+	 * @deprecated Reflective APIs for adding widgets are deprecated. Use {@link #createChild(Supplier, Position)} instead.
 	 */
+	@Deprecated
 	default <W extends WAbstractWidget> W createChild(Class<W> wClass, Position position) {
 		return createChild(wClass, position, null);
+	}
+
+	/**
+	 * Convenience method for short-circuiting {@code factory.get()} and setting the widget's
+	 * position.
+	 *
+	 * @param factory  widget factory
+	 * @param position initial widget position
+	 * @return created widget
+	 */
+	default <W extends WAbstractWidget> W createChild(Supplier<W> factory, Position position) {
+		return createChild(factory, position, null);
 	}
 }


### PR DESCRIPTION
Making controversial PRs is fun. :tiny_potato:

- `createChild` methods that take a `Class<W>` have been replaced by ones that take `Supplier<W>`.
  - Example: `panel.createChild(WButton::new).setLabel(new LiteralText("lil tater"))`
- `@WFocused[Mouse/Keyboard]Listener` have been replaced by `WAbstractWidget.isFocused[Mouse/Keyboard]Listener`.