### PR TITLE
Fix slot locking

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ yarn_mappings=1.15.2+build.14
 loader_version=0.7.8+build.187
 
 # Mod Properties
-mod_version = 2.0.24
+mod_version = 2.0.25
 version_meta = fabric-1.15.2
 maven_group = com.github.vini2003
 archives_base_name = spinnery

--- a/src/main/java/spinnery/common/BaseContainer.java
+++ b/src/main/java/spinnery/common/BaseContainer.java
@@ -196,6 +196,10 @@ public class BaseContainer extends Container {
 
 		WSlot slotA = slotT;
 
+		if(slotA.isLocked()) {
+			return;
+		}
+
 		ItemStack stackA = slotA.getStack().copy();
 		ItemStack stackB = player.inventory.getCursorStack().copy();
 
@@ -246,6 +250,9 @@ public class BaseContainer extends Container {
 				for (WAbstractWidget widget : serverInterface.getAllWidgets()) {
 					if (widget instanceof WSlot && ((WSlot) widget).getLinkedInventory() != slotA.getLinkedInventory()) {
 						WSlot slotB = ((WSlot) widget);
+
+						if (slotB.isLocked()) continue;
+
 						ItemStack stackC = slotB.getStack();
 						stackA = slotA.getStack();
 


### PR DESCRIPTION
Fix for #32. 

I first poll for whether or not the main slot is locked, and then added 1 check for the secondary slot for `QUICK_MOVE`. Tested and working on 1.15.2 for shift clicking, left clicking, item pickup, and right clicking.
