### PR TITLE
Resolve #38 and remove convolution

### DIFF
--- a/src/main/java/spinnery/widget/WTabHolder.java
+++ b/src/main/java/spinnery/widget/WTabHolder.java
@@ -6,7 +6,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
-import spinnery.client.BaseRenderer;
 import spinnery.widget.api.Position;
 import spinnery.widget.api.Size;
 import spinnery.widget.api.WCollection;
@@ -19,7 +18,6 @@ import spinnery.widget.api.WModifiableCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -31,12 +29,7 @@ public class WTabHolder extends WAbstractWidget implements WCollection, WDelegat
 
 	public void selectTab(int tabNumber) {
 		for (WTab tab : tabs) {
-			if (tab.getNumber() != tabNumber) {
-				tab.getToggle().setToggleState(false);
-			}
-			for (WAbstractWidget widget : tab.getWidgets()) {
-				widget.setHidden(tab.getNumber() != tabNumber);
-			}
+			tab.setActive(tab.getNumber() == tabNumber);
 		}
 	}
 
@@ -108,18 +101,9 @@ public class WTabHolder extends WAbstractWidget implements WCollection, WDelegat
 			return;
 		}
 
-		int x = getX();
-		int y = getY();
-		int z = getZ();
-
-		int sX = getWidth();
-		int sY = getHeight();
-
 		for (WTab tab : tabs) {
 			tab.getToggle().draw();
 		}
-
-		BaseRenderer.drawPanel(x, y + 24, z, sX, sY - 24, getStyle().asColor("shadow"), getStyle().asColor("background"), getStyle().asColor("highlight"), getStyle().asColor("outline"));
 
 		for (WTab tab : tabs) {
 			tab.draw();
@@ -129,8 +113,7 @@ public class WTabHolder extends WAbstractWidget implements WCollection, WDelegat
 	public class WTab extends WAbstractWidget implements WDrawableCollection, WModifiableCollection, WDelegatedEventListener {
 		protected int number;
 		protected WTabToggle toggle;
-		protected Set<WAbstractWidget> widgets = new LinkedHashSet<>();
-		protected List<WLayoutElement> orderedWidgets = new ArrayList<>();
+		protected WPanel body = new WPanel();
 
 		public WTab() {
 			toggle = WWidgetFactory.buildDetached(WTabToggle.class)
@@ -138,68 +121,53 @@ public class WTabHolder extends WAbstractWidget implements WCollection, WDelegat
 					.setSize(Size.of(36, 24))
 					.setParent(this)
 					.setInterface(WTabHolder.this.getInterface());
+
+			body.setParent(this).getPosition().setAnchor(WTabHolder.this).setOffsetY(24);
 		}
 
 		@Override
 		public Collection<? extends WEventListener> getEventDelegates() {
-			Set<WAbstractWidget> delegates = new HashSet<>(widgets);
-			delegates.add(toggle);
-			return delegates;
+			Collection<? extends WEventListener> bodyDelegates = body.getEventDelegates();
+			Collection<WEventListener> returnList = new ArrayList<WEventListener>(bodyDelegates);
+			returnList.add(toggle);
+			return returnList;
 		}
 
 		@Override
 		public void add(WAbstractWidget... widgets) {
-			for (WAbstractWidget newWidget : widgets) {
-				newWidget.setInterface(WTabHolder.this.getInterface());
-				newWidget.setParent(this);
-				this.widgets.add(newWidget);
-			}
-			for (WAbstractWidget widget : getWidgets()) {
-				if (!(widget instanceof WTabToggle)) {
-					widget.setHidden(true);
-				}
-			}
+			body.add(widgets);
 			onLayoutChange();
 		}
 
-		public Set<WAbstractWidget> getWidgets() {
-			return widgets;
-		}
+		public Set<WAbstractWidget> getWidgets() { return body.getWidgets(); }
 
 		@Override
 		public void onLayoutChange() {
 			super.onLayoutChange();
+			body.setSize(WTabHolder.this.getSize().add(0, -24));
 			recalculateCache();
 		}
 
 		@Override
 		public void recalculateCache() {
-			orderedWidgets = new ArrayList<>(getWidgets());
-			Collections.sort(orderedWidgets);
-			Collections.reverse(orderedWidgets);
+			body.recalculateCache();
 		}
 
 		@Override
-		public List<WLayoutElement> getOrderedWidgets() {
-			return orderedWidgets;
-		}
+		public List<WLayoutElement> getOrderedWidgets() { return body.getOrderedWidgets(); }
 
 		@Override
-		public boolean contains(WAbstractWidget... widgets) {
-			return this.widgets.containsAll(Arrays.asList(widgets));
-		}
+		public boolean contains(WAbstractWidget... widgets) { return body.contains(widgets); }
 
 		@Override
 		public void remove(WAbstractWidget... widgets) {
-			this.widgets.removeAll(Arrays.asList(widgets));
+			body.remove(widgets);
 			onLayoutChange();
 		}
 
 		@Override
 		public void draw() {
-			for (WLayoutElement widget : getOrderedWidgets()) {
-				widget.draw();
-			}
+			body.draw();
 		}
 
 		public int getNumber() {
@@ -224,5 +192,12 @@ public class WTabHolder extends WAbstractWidget implements WCollection, WDelegat
 			getToggle().setLabel(name);
 			return this;
 		}
+
+		public void setActive(boolean isActive) {
+			getToggle().setToggleState(isActive);
+			body.setHidden(!isActive);
+		}
+
+		public WPanel getBody() { return body; }
 	}
 }


### PR DESCRIPTION
This offloads a lot of WTabHolder's work to WPanel by having each tab store its widgets in a WPanel. This removes a lot of convolution by only requiring interactions with one object and removes some code that would be duplicated in WPanel. It also resolves #38 by allowing access to the body panel. This doesn't change any behavior other than adding the body panel, it just does things in a better way.