### PR TITLE
Add sprite related widgets

### DIFF
--- a/src/main/java/spinnery/client/render/BaseRenderer.java
+++ b/src/main/java/spinnery/client/render/BaseRenderer.java
@@ -96,20 +96,24 @@ public class BaseRenderer {
 	}
 
 	public static void drawImage(double x, double y, double z, double sX, double sY, Identifier texture) {
-		getTextureManager().bindTexture(texture);
+		drawSprite(x, y, z, sX, sY, texture, 0, 0, 1, 1);
+	}
+
+	public static void drawSprite(double x, double y, double z, double sX, double sY, Identifier texture, float u1, float v1, float u2, float v2) {
+		BaseRenderer.getTextureManager().bindTexture(texture);
 
 		RenderSystem.enableBlend();
 		RenderSystem.blendFuncSeparate(770, 771, 1, 0);
 		RenderSystem.color4f(255, 255, 255, 255);
 
-		getBufferBuilder().begin(GL11.GL_QUADS, VertexFormats.POSITION_TEXTURE);
+		BaseRenderer.getBufferBuilder().begin(GL11.GL_QUADS, VertexFormats.POSITION_TEXTURE);
 
-		getBufferBuilder().vertex(x, y + sY, 0).texture(0, 1).next();
-		getBufferBuilder().vertex(x + sX, y + sY, 0).texture(1, 1).next();
-		getBufferBuilder().vertex(x + sX, y, 0).texture(1, 0).next();
-		getBufferBuilder().vertex(x, y, 0).texture(0, 0).next();
+		BaseRenderer.getBufferBuilder().vertex(x, y + sY, 0).texture(u1, v2).next();
+		BaseRenderer.getBufferBuilder().vertex(x + sX, y + sY, 0).texture(u2, v2).next();
+		BaseRenderer.getBufferBuilder().vertex(x + sX, y, 0).texture(u2, v1).next();
+		BaseRenderer.getBufferBuilder().vertex(x, y, 0).texture(u1, v1).next();
 
-		getTesselator().draw();
+		BaseRenderer.getTesselator().draw();
 
 		RenderSystem.disableBlend();
 	}

--- a/src/main/java/spinnery/client/utility/SpriteSheet.java
+++ b/src/main/java/spinnery/client/utility/SpriteSheet.java
@@ -1,0 +1,99 @@
+package spinnery.client.utility;
+
+import net.minecraft.util.Identifier;
+import spinnery.client.render.BaseRenderer;
+
+/**
+ * Provides utilities for using texture atlases. Used by
+ * {@link spinnery.widget.WSprite} and {@link spinnery.widget.WStatusBar.BarConfig}
+ * for drawing sprites.
+ */
+public class SpriteSheet {
+    /**
+     * The set of HUD icons used by Minecraft itself, for
+     * rendering things like health, hunger, oxygen.
+     * This sheet has 18 icons per row.
+     */
+    public static final SpriteSheet MINECRAFT_ICONS = new SpriteSheet(new Identifier("minecraft:textures/gui/icons.png"), 256, 256).crop(16, 0, 162, 54).setDimensions(9, 9);
+
+    public static class Sprite {
+        public final Identifier atlas;
+        public final float x;
+        public final float y;
+        public final float w;
+        public final float h;
+
+        public Sprite(Identifier atlas, float x, float y, float w, float h) {
+            this.atlas = atlas;
+            this.x = x;
+            this.y = y;
+            this.w = w;
+            this.h = h;
+        }
+
+        public void draw(double x, double y, double z, double sX, double sY, boolean mirror) {
+            float u1 = this.x;
+            float v1 = this.y;
+            float u2 = u1 + this.w;
+            float v2 = v1 + this.h;
+
+            if (mirror) {
+                // Swap UVs.
+                float temp = u2;
+                u2 = u1;
+                u1 = temp;
+            }
+
+            BaseRenderer.drawSprite(x, y, z, sX, sY, atlas, u1, v1, u2, v2);
+        }
+    }
+
+    private Identifier atlasId;
+    private int startX = 0;
+    private int startY = 0;
+    private int sizeX;
+    private int sizeY;
+    private int endX;
+    private int endY;
+    private int spriteWidth = 16;
+    private int spriteHeight = 16;
+
+    public SpriteSheet(Identifier atlasId, int w, int h) {
+        this.atlasId = atlasId;
+        this.sizeX = w;
+        this.sizeY = h;
+        this.endX = w;
+        this.endY = h;
+    }
+
+    public SpriteSheet crop(int x, int y) {
+        startX = x;
+        startY = y;
+        return this;
+    }
+
+    public SpriteSheet crop(int x, int y, int w, int h) {
+        startX = x;
+        startY = y;
+        endX = x + w;
+        endY = y + h;
+        return this;
+    }
+
+    public SpriteSheet setDimensions(int w, int h) {
+        spriteWidth = w;
+        spriteHeight = h;
+        return this;
+    }
+
+    public Sprite getSprite(int index) {
+        int spritesPerRow = (endX - startX) / spriteWidth;
+        int row = index / spritesPerRow;
+        int column = index % spritesPerRow;
+
+        int x = column * spriteWidth + startX;
+        int y = row * spriteHeight + startY;
+
+        return new Sprite(atlasId, x / (float)sizeX, y / (float)sizeY, spriteWidth / (float)sizeX, spriteHeight / (float)sizeY);
+    }
+}

--- a/src/main/java/spinnery/common/registry/WidgetRegistry.java
+++ b/src/main/java/spinnery/common/registry/WidgetRegistry.java
@@ -60,6 +60,8 @@ public class WidgetRegistry {
 		register(new Identifier("spinnery", "vertical_arrow_up"), WVerticalArrowUp.class);
 		register(new Identifier("spinnery", "vertical_arrow_down"), WVerticalArrowDown.class);
 		register(new Identifier("spinnery", "option_field"), WOptionField.class);
+		register(new Identifier("spinnery", "sprite"), WSprite.class);
+		register(new Identifier("spinnery", "status_bar"), WStatusBar.class);
 	}
 
 	public static void register(Identifier id, Class<? extends WAbstractWidget> wClass) {

--- a/src/main/java/spinnery/widget/WSprite.java
+++ b/src/main/java/spinnery/widget/WSprite.java
@@ -1,0 +1,32 @@
+package spinnery.widget;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import spinnery.client.utility.SpriteSheet;
+
+/**
+ * Allows you to render a sprite that's been packed into a texture atlas.
+ * Specifically useful for rendering icons and other bits from the Minecraft resources.
+ */
+@Environment(EnvType.CLIENT)
+public class WSprite extends WAbstractWidget {
+    private SpriteSheet.Sprite sprite;
+
+    public SpriteSheet.Sprite getSprite() {
+        return sprite;
+    }
+
+    public <W extends WSprite> W setSprite(SpriteSheet.Sprite sprite) {
+        this.sprite = sprite;
+        return (W) this;
+    }
+
+    @Override
+    public void draw() {
+        if (isHidden()) {
+            return;
+        }
+
+        getSprite().draw(getX(), getY(), getZ(), getWidth(), getHeight(), false);
+    }
+}

--- a/src/main/java/spinnery/widget/WStatusBar.java
+++ b/src/main/java/spinnery/widget/WStatusBar.java
@@ -1,0 +1,139 @@
+package spinnery.widget;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import spinnery.client.utility.SpriteSheet;
+import spinnery.widget.api.*;
+
+/**
+ * Used to render a status bar, such as a health or hunger bar. Visuals are specified using a {@link BarConfig}.
+ */
+@Environment(EnvType.CLIENT)
+public class WStatusBar extends WAbstractWidget {
+    private static final SpriteSheet ICONS = SpriteSheet.MINECRAFT_ICONS;
+    /**
+     * The normal health bar without any status modifiers.
+     */
+    public static final BarConfig HEALTH_DEFAULT = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(4), ICONS.getSprite(5), BarConfig.Direction.LeftToRight);
+    public static final BarConfig HEALTH_WITHER = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(12), ICONS.getSprite(13), BarConfig.Direction.LeftToRight);
+    public static final BarConfig HEALTH_POISON = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(8), ICONS.getSprite(9), BarConfig.Direction.LeftToRight);
+    /**
+     * The normal food bar. Note that this is a right to left bar by default. You can mirror it using {@link BarConfig#mirror()}.
+     */
+    public static final BarConfig FOOD_DEFAULT = new BarConfig(ICONS.getSprite(54), ICONS.getSprite(58), ICONS.getSprite(59), BarConfig.Direction.RightToLeft);
+    /**
+     * Food bar with the hunger status effect.
+     */
+    public static final BarConfig FOOD_HUNGER = new BarConfig(ICONS.getSprite(56), ICONS.getSprite(62), ICONS.getSprite(63), BarConfig.Direction.RightToLeft);
+    public static final BarConfig ARMOR_DEFAULT = new BarConfig(ICONS.getSprite(18), ICONS.getSprite(20), ICONS.getSprite(19), BarConfig.Direction.LeftToRight);
+
+    public static class BarConfig {
+        // Always renders, even behind full sprites.
+        public final SpriteSheet.Sprite background;
+        public final SpriteSheet.Sprite full;
+        public final SpriteSheet.Sprite half;
+        // Some bars are specified in their atlas using a right-to-left texture, such as the hunger bar icons.
+        public final Direction direction;
+        // This allows you to flip a right to left bar around to make it left to right.
+        public final boolean mirror;
+        // These are 9 for all Minecraft bars, but you can change them if you're making a custom bar.
+        public final int spriteWidth;
+        public final int spriteHeight;
+
+        public enum Direction {
+            LeftToRight,
+            RightToLeft,
+        }
+
+        public BarConfig(SpriteSheet.Sprite background, SpriteSheet.Sprite full, SpriteSheet.Sprite half, Direction direction) {
+            this(background, full, half, direction, false, 9, 9);
+        }
+
+        private BarConfig(SpriteSheet.Sprite background, SpriteSheet.Sprite full, SpriteSheet.Sprite half, Direction direction, boolean mirror, int width, int height) {
+            this.background = background;
+            this.full = full;
+            this.half = half;
+            this.direction = direction;
+            this.mirror = mirror;
+            this.spriteWidth = width;
+            this.spriteHeight = height;
+        }
+
+        public BarConfig setSize(int width, int height) {
+            return new BarConfig(background, full, half, direction, mirror, width, height);
+        }
+
+        // Renders the bar backwards, which is useful for hunger bars which are RTL in the atlas.
+        public BarConfig mirror() {
+            return new BarConfig(background, full, half, direction, !mirror, spriteWidth, spriteHeight);
+        }
+    }
+
+    private BarConfig config = HEALTH_DEFAULT;
+    private int value;
+    private int maxValue;
+
+    public BarConfig getConfig() {
+        return config;
+    }
+
+    public <W extends WStatusBar> W setConfig(BarConfig config) {
+        this.config = config;
+
+        updateSize();
+
+        return (W) this;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the values of the bar.
+     * @param value The current value, for health bars this would be {@link net.minecraft.entity.LivingEntity#getHealth}.
+     * @param maxValue The highest possible value, for health bars this would be {@link net.minecraft.entity.LivingEntity#getMaximumHealth}.
+     */
+    public <W extends WStatusBar> W setValue(int value, int maxValue) {
+        this.maxValue = maxValue;
+        this.value = Math.min(value, maxValue);
+
+        updateSize();
+
+        return (W) this;
+    }
+
+    protected void updateSize() {
+        int numContainers = (maxValue + 1) / 2;
+        setSize(Size.of(config.spriteWidth * numContainers, config.spriteHeight));
+    }
+
+    @Override
+    public void draw() {
+        if (isHidden()) {
+            return;
+        }
+
+        int numContainers = (maxValue + 1) / 2;
+        for (int i = 0; i < numContainers; i++) {
+            boolean flip = config.direction == BarConfig.Direction.RightToLeft;
+            if (config.mirror) {
+                flip = !flip;
+            }
+            int x = i * config.spriteWidth;
+            if (flip) {
+                x = (numContainers - i - 1) * config.spriteWidth;
+            }
+
+            config.background.draw(getX() + x, getY(), getZ(), config.spriteWidth, config.spriteHeight, config.mirror);
+
+            if (i * 2 <= value) {
+                SpriteSheet.Sprite sprite = config.half;
+                if (value - 2 * i > 1.0F) {
+                    sprite = config.full;
+                }
+                sprite.draw(getX() + x, getY(), getZ() + 1, config.spriteWidth, config.spriteHeight, config.mirror);
+            }
+        }
+    }
+}

--- a/src/main/java/spinnery/widget/WStatusBar.java
+++ b/src/main/java/spinnery/widget/WStatusBar.java
@@ -14,18 +14,18 @@ public class WStatusBar extends WAbstractWidget {
     /**
      * The normal health bar without any status modifiers.
      */
-    public static final BarConfig HEALTH_DEFAULT = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(4), ICONS.getSprite(5), BarConfig.Direction.LeftToRight);
-    public static final BarConfig HEALTH_WITHER = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(12), ICONS.getSprite(13), BarConfig.Direction.LeftToRight);
-    public static final BarConfig HEALTH_POISON = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(8), ICONS.getSprite(9), BarConfig.Direction.LeftToRight);
+    public static final BarConfig HEALTH_DEFAULT = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(4), ICONS.getSprite(5), BarConfig.Direction.LEFT_TO_RIGHT);
+    public static final BarConfig HEALTH_WITHER = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(12), ICONS.getSprite(13), BarConfig.Direction.LEFT_TO_RIGHT);
+    public static final BarConfig HEALTH_POISON = new BarConfig(ICONS.getSprite(0), ICONS.getSprite(8), ICONS.getSprite(9), BarConfig.Direction.LEFT_TO_RIGHT);
     /**
      * The normal food bar. Note that this is a right to left bar by default. You can mirror it using {@link BarConfig#mirror()}.
      */
-    public static final BarConfig FOOD_DEFAULT = new BarConfig(ICONS.getSprite(54), ICONS.getSprite(58), ICONS.getSprite(59), BarConfig.Direction.RightToLeft);
+    public static final BarConfig FOOD_DEFAULT = new BarConfig(ICONS.getSprite(54), ICONS.getSprite(58), ICONS.getSprite(59), BarConfig.Direction.RIGHT_TO_LEFT);
     /**
      * Food bar with the hunger status effect.
      */
-    public static final BarConfig FOOD_HUNGER = new BarConfig(ICONS.getSprite(56), ICONS.getSprite(62), ICONS.getSprite(63), BarConfig.Direction.RightToLeft);
-    public static final BarConfig ARMOR_DEFAULT = new BarConfig(ICONS.getSprite(18), ICONS.getSprite(20), ICONS.getSprite(19), BarConfig.Direction.LeftToRight);
+    public static final BarConfig FOOD_HUNGER = new BarConfig(ICONS.getSprite(56), ICONS.getSprite(62), ICONS.getSprite(63), BarConfig.Direction.RIGHT_TO_LEFT);
+    public static final BarConfig ARMOR_DEFAULT = new BarConfig(ICONS.getSprite(18), ICONS.getSprite(20), ICONS.getSprite(19), BarConfig.Direction.LEFT_TO_RIGHT);
 
     public static class BarConfig {
         // Always renders, even behind full sprites.
@@ -41,8 +41,8 @@ public class WStatusBar extends WAbstractWidget {
         public final int spriteHeight;
 
         public enum Direction {
-            LeftToRight,
-            RightToLeft,
+            LEFT_TO_RIGHT,
+            RIGHT_TO_LEFT,
         }
 
         public BarConfig(SpriteSheet.Sprite background, SpriteSheet.Sprite full, SpriteSheet.Sprite half, Direction direction) {
@@ -116,7 +116,7 @@ public class WStatusBar extends WAbstractWidget {
 
         int numContainers = (maxValue + 1) / 2;
         for (int i = 0; i < numContainers; i++) {
-            boolean flip = config.direction == BarConfig.Direction.RightToLeft;
+            boolean flip = config.direction == BarConfig.Direction.RIGHT_TO_LEFT;
             if (config.mirror) {
                 flip = !flip;
             }


### PR DESCRIPTION
Adds WSprite and related utilities for rendering sprites that are stored in texture atlases, particularly the default Minecraft ones like `textures/gui/icons.png`.

Also adds WStatusBar, which can render health or hunger bars. It's not meant to completely replicate the vanilla health bar, as it doesn't support things like absorption hearts or lost health indicators.

```java
        int maxHealth = (int) myEntity.getMaximumHealth();
        int health = (int) myEntity.getHealth();
        WStatusBar healthBar = new WStatusBar().setConfig(WStatusBar.HEALTH_DEFAULT).setValue(health, maxHealth);
```

![image](https://user-images.githubusercontent.com/1254344/85212958-064edd80-b30d-11ea-9f03-db672dd3abf7.png)

![image](https://user-images.githubusercontent.com/1254344/85212942-ca1b7d00-b30c-11ea-934f-25d457fcc9fa.png)
